### PR TITLE
fix css calc warning

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -35,7 +35,7 @@ export default {
 @import "./assets/scss/main.scss";
 
 :root {
-  --main-height: calc(100vh - 76px -5rem);
+  --main-height: calc(100vh - 76px - 5rem);
 }
 
 body {


### PR DESCRIPTION
minor change + able to test the re-deploy runtime
First time multi-arch docker build took ~3.5 min.. will a second time be cached and ready to update quicker?